### PR TITLE
Logic for opening and closing rows (TRs)

### DIFF
--- a/lib/donatj/SimpleCalendar.php
+++ b/lib/donatj/SimpleCalendar.php
@@ -149,13 +149,14 @@ class SimpleCalendar {
 
 			$out .= "</td>";
 
-			if( $count > 6 && $i < $no_days ) {
-				$out   .= "</tr>\n" . ($i != $count ? '<tr>' : '');
+			if( $count > 6 ) {
+				$out .= "</tr>\n" . ($i < $no_days ? '<tr>' : '');
 				$count = 0;
 			}
 			$count++;
 		}
-		$out .= ($count != 1 ? str_repeat('<td class="SCsuffix">&nbsp;</td>', 8 - $count) : '') . "</tr>\n</tbody></table>\n";
+		$out .= ( $count != 1 ) ? str_repeat('<td class="SCsuffix">&nbsp;</td>', 8 - $count) . '</tr>' : '';
+		$out .= "\n</tbody></table>\n";
 		if( $echo ) {
 			echo $out;
 		}


### PR DESCRIPTION
This pull request fixes a missing opening TR tag for months that don't have empty leading days like January 2017. It also takes care of trailing TRs 31fca8ea577a1cae720422964e2e3e265b0707b6

This issue only happens on day 7 because the `$count` variable is reset to 0. 

This is the logic.
```php
if( $count > 6 && $i < $no_days ) {
	$out   .= "</tr>\n" . ($i != $count ? '<tr>' : '');
	$count = 0;
}
```

And here is the logic when looping through January 2017.
```
open first row
    $i=1 | $count=1
    $i=2 | $count=2
    $i=3 | $count=3
    $i=4 | $count=4
    $i=5 | $count=5
    $i=6 | $count=6
    $i=7 | $count=7
close row ( 7 > 6 && 7 < 31 )
don't open new row (7 == 7) [missing TR]
    $i=8 | $count=1
    $i=9 | $count=2
    $i=10 | $count=3
    $i=11 | $count=4
    $i=12 | $count=5
    $i=13 | $count=6
    $i=14 | $count=7
close row  ( 7 > 6 && 14 < 31 )
open new row ( 14 != 7)
    $i=15 | $count=1
    $i=16 | $count=2
etc
```
