### PR TITLE
Use custom classes in the calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,29 @@ Returns/Outputs the Calendar
 ##### Returns:
 
 - ***string*** - HTML of the Calendar
+
+---
+
+#### Method: SimpleCalendar->setCalendarClasses
+
+```php
+function setCalendarClasses([ $classes = null ])
+```
+
+Sets the class names used in the calendar
+
+##### Parameters:
+
+- ***array*** `$classes` - Array with classes used in the calendar
+
+The default classes uses in the calendar are
+```php
+$classes = array(
+	'calendar'      => 'SimpleCalendar',
+	'leading_day'   => 'SCprefix',
+	'trailing_day'  => 'SCsuffix',
+	'today'         => 'today',
+	'event'         => 'event',
+	'events'        => 'events',
+);
+```

--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ Sets the class names used in the calendar
 
 ##### Parameters:
 
-- ***array*** `$classes` - Array with classes used in the calendar
+- ***null*** | ***array*** `$classes` - Array with classes used in the calendar
 
-The default classes uses in the calendar are
+The default classes used in the calendar are
 ```php
 $classes = array(
 	'calendar'      => 'SimpleCalendar',

--- a/lib/donatj/SimpleCalendar.php
+++ b/lib/donatj/SimpleCalendar.php
@@ -49,18 +49,18 @@ class SimpleCalendar {
 	}
 
 	/**
-	 * Sets the class names used by the calendar
+	 * Sets the class names used in the calendar
 	 *
 	 * @param array $classes Array with classnames used by the calendar
 	 */
 	public function setCalendarClasses( $classes = null ) {
 		$defaults = array(
-			'calendar' => 'SimpleCalendar',
-			'prefix'   => 'SCprefix',
-			'suffix'   => 'SCsuffix',
-			'today'    => 'today',
-			'event'    => 'event',
-			'events'   => 'events',
+			'calendar'      => 'SimpleCalendar',
+			'leading_day'   => 'SCprefix',
+			'trailing_day'  => 'SCsuffix',
+			'today'         => 'today',
+			'event'         => 'event',
+			'events'        => 'events',
 		);
 
 		if( ! $classes || ! is_array( $classes ) ) {
@@ -149,7 +149,7 @@ class SimpleCalendar {
 		if( $wday == 7 ) {
 			$wday = 0;
 		} else {
-			$out .= str_repeat('<td class="' . $this->classes['prefix'] . '">&nbsp;</td>', $wday);
+			$out .= str_repeat('<td class="' . $this->classes['leading_day'] . '">&nbsp;</td>', $wday);
 		}
 
 		$count = $wday + 1;
@@ -181,7 +181,7 @@ class SimpleCalendar {
 			}
 			$count++;
 		}
-		$out .= ( $count != 1 ) ? str_repeat('<td class="' . $this->classes['suffix'] . '">&nbsp;</td>', 8 - $count) . '</tr>' : '';
+		$out .= ( $count != 1 ) ? str_repeat('<td class="' . $this->classes['trailing_day'] . '">&nbsp;</td>', 8 - $count) . '</tr>' : '';
 		$out .= "\n</tbody></table>\n";
 		if( $echo ) {
 			echo $out;

--- a/lib/donatj/SimpleCalendar.php
+++ b/lib/donatj/SimpleCalendar.php
@@ -20,17 +20,19 @@ class SimpleCalendar {
 	public $wday_names = false;
 
 	private $now;
+	private $classes;
 	private $dailyHtml = array();
 	private $offset = 0;
 
 	/**
-	 * Constructor - Calls the setDate function
+	 * Constructor - Calls the setDate and setCalendarClasses functions
 	 *
 	 * @see setDate
 	 * @param null|string $date_string
 	 */
 	public function __construct( $date_string = null ) {
 		$this->setDate($date_string);
+		$this->setCalendarClasses();
 	}
 
 	/**
@@ -44,6 +46,28 @@ class SimpleCalendar {
 		} else {
 			$this->now = getdate();
 		}
+	}
+
+	/**
+	 * Sets the class names used by the calendar
+	 *
+	 * @param array $classes Array with classnames used by the calendar
+	 */
+	public function setCalendarClasses( $classes = null ) {
+		$defaults = array(
+			'calendar' => 'SimpleCalendar',
+			'prefix'   => 'SCprefix',
+			'suffix'   => 'SCsuffix',
+			'today'    => 'today',
+			'event'    => 'event',
+			'events'   => 'events',
+		);
+
+		if( ! $classes || ! is_array( $classes ) ) {
+			$classes = $defaults;
+		}
+
+		$this->classes = array_merge( $defaults, $classes );
 	}
 
 	/**
@@ -112,7 +136,7 @@ class SimpleCalendar {
 		$wday    = date('N', mktime(0, 0, 1, $this->now['mon'], 1, $this->now['year'])) - $this->offset;
 		$no_days = cal_days_in_month(CAL_GREGORIAN, $this->now['mon'], $this->now['year']);
 
-		$out = '<table cellpadding="0" cellspacing="0" class="SimpleCalendar"><thead><tr>';
+		$out = '<table cellpadding="0" cellspacing="0" class="' . $this->classes['calendar'] . '"><thead><tr>';
 
 		for( $i = 0; $i < 7; $i++ ) {
 			$out .= '<th>' . $wdays[$i] . '</th>';
@@ -125,12 +149,12 @@ class SimpleCalendar {
 		if( $wday == 7 ) {
 			$wday = 0;
 		} else {
-			$out .= str_repeat('<td class="SCprefix">&nbsp;</td>', $wday);
+			$out .= str_repeat('<td class="' . $this->classes['prefix'] . '">&nbsp;</td>', $wday);
 		}
 
 		$count = $wday + 1;
 		for( $i = 1; $i <= $no_days; $i++ ) {
-			$out .= '<td' . ($i == $this->now['mday'] && $this->now['mon'] == date('n') && $this->now['year'] == date('Y') ? ' class="today"' : '') . '>';
+			$out .= '<td' . ($i == $this->now['mday'] && $this->now['mon'] == date('n') && $this->now['year'] == date('Y') ? ' class="' . $this->classes['today'] .'"' : '') . '>';
 
 			$datetime = mktime(0, 0, 1, $this->now['mon'], $i, $this->now['year']);
 
@@ -142,9 +166,11 @@ class SimpleCalendar {
 			}
 
 			if( is_array($dHtml_arr) ) {
+				$out .= '<div class="' . $this->classes['events'] . '">';
 				foreach( $dHtml_arr as $dHtml ) {
-					$out .= '<div class="event">' . $dHtml . '</div>';
+					$out .= '<div class="' . $this->classes['event'] . '">' . $dHtml . '</div>';
 				}
+				$out .= '</div>';
 			}
 
 			$out .= "</td>";
@@ -155,7 +181,7 @@ class SimpleCalendar {
 			}
 			$count++;
 		}
-		$out .= ( $count != 1 ) ? str_repeat('<td class="SCsuffix">&nbsp;</td>', 8 - $count) . '</tr>' : '';
+		$out .= ( $count != 1 ) ? str_repeat('<td class="' . $this->classes['suffix'] . '">&nbsp;</td>', 8 - $count) . '</tr>' : '';
 		$out .= "\n</tbody></table>\n";
 		if( $echo ) {
 			echo $out;

--- a/test/SimpleCalendarTest.php
+++ b/test/SimpleCalendarTest.php
@@ -29,12 +29,12 @@ class SimpleCalendarTest extends PHPUnit_Framework_TestCase {
 	public function testCustomCallendarClasses() {
 		$cal = new \donatj\SimpleCalendar();
 		$classes = array(
-			'calendar' => 'TestCalendar',
-			'prefix'   => 'TestPrefix',
-			'suffix'   => 'TestSuffix',
-			'today'    => 'TestToday',
-			'event'    => 'TestEvent',
-			'events'   => 'TestEvents',
+			'calendar'     => 'TestCalendar',
+			'leading_day'  => 'TestPrefix',
+			'trailing_day' => 'TestSuffix',
+			'today'        => 'TestToday',
+			'event'        => 'TestEvent',
+			'events'       => 'TestEvents',
 		);
 
 		$cal->setCalendarClasses( $classes );

--- a/test/SimpleCalendarTest.php
+++ b/test/SimpleCalendarTest.php
@@ -8,6 +8,44 @@ class SimpleCalendarTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains('class="today"', $cal->show(false));
 	}
 
+	public function testCallendarClasses() {
+		$cal = new \donatj\SimpleCalendar();
+		$defaults = array(
+			'SimpleCalendar',
+			'SCprefix',
+			'SCsuffix',
+			'today',
+			'event',
+			'events',
+		);
+
+		$cal->addDailyHtml( 'Sample Event', 'today' );
+        $cal_html = $cal->show(false);
+		foreach( $defaults as $class ) {
+			$this->assertContains('class="' . $class . '"', $cal_html);
+		}
+	}
+
+	public function testCustomCallendarClasses() {
+		$cal = new \donatj\SimpleCalendar();
+		$classes = array(
+			'calendar' => 'TestCalendar',
+			'prefix'   => 'TestPrefix',
+			'suffix'   => 'TestSuffix',
+			'today'    => 'TestToday',
+			'event'    => 'TestEvent',
+			'events'   => 'TestEvents',
+		);
+
+		$cal->setCalendarClasses( $classes );
+		$cal->addDailyHtml( 'Sample Event', 'today' );
+		$cal_html = $cal->show(false);
+
+		foreach( $classes as $class ) {
+			$this->assertContains('class="' . $class . '"', $cal_html);
+		}
+	}
+
 	public function testCurrentMonth_yearRegression() {
 		$cal = new \donatj\SimpleCalendar(sprintf('%d-%d-%d', (date('Y') - 1), date('n'), date('d')));
 		$this->assertNotContains('class="today"', $cal->show(false));


### PR DESCRIPTION
This PR adds custom control over the classes used in the calendar. It allows you to have calendars styled differently from the base style (e.g. `table.SimpleCalendar.small`). It can also fix conflicts with styles from other packages using the same class selectors as used in the calendar (e.g. `.today`, `.event`).

Example using custom classes.

```php
$calendar = new donatj\SimpleCalendar();
// add a `small` class to the calendar
$calendar->setCalendarClasses( array( 'calendar' => 'SimpleCalendar small' ) );
$calendar->addDailyHtml( 'Sample Event', 'today', 'tomorrow' );
$calendar->show( true );
```

This pr also adds a `div.events` container for the events. This allows you to add a scroll bar to a `td` tag.
https://stackoverflow.com/a/14058571