### PR TITLE
Allow class to be extendable and add disable class to mark all days from the past to be greyed out

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		"ext-calendar": "*"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "4.*"
+		"phpunit/phpunit": "^9"
 	},
 	"authors"    : [
 		{

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-	"name"       : "donatj/simplecalendar",
+	"name"       : "krzysiaczek/simplecalendar",
 	"type"       : "library",
-	"description": "A light, easy to use calendar rendering library",
+	"description": "An extension of light, easy to use calendar rendering library written by Jesse G. Donat",
 	"keywords"   : ["calendar"],
 	"homepage"   : "http://donatstudios.com/SimpleCalendar",
 	"license"    : "MIT",
@@ -18,8 +18,19 @@
 			"email"   : "donatj@gmail.com",
 			"homepage": "http://donatstudios.com",
 			"role"    : "Developer"
+		},
+		{
+			"name"    : "Krzysiaczek",
+			"email"   : "krzysiaczek@icloud.com",
+			"role"    : "Developer"
 		}
 	],
+	"repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/Krzysiaczek/SimpleCalendar.git"
+        }
+    ],
 	"autoload"   : {
 		"psr-4": {
 			"donatj\\": "src/"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,11 +1,14 @@
-<phpunit bootstrap="vendor/autoload.php">
-	<testsuites>
-		<testsuite name="Application">
-			<directory>test</directory>
-		</testsuite>
-	</testsuites>
-
-	<logging>
-		<log type="coverage-clover" target="clover.xml"/>
-	</logging>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <report>
+      <clover outputFile="clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Application">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/src/SimpleCalendar.php
+++ b/src/SimpleCalendar.php
@@ -269,7 +269,18 @@ TAG
 					&& $today['year'] == $date->format('Y');
 			}
 
-			$out .= '<td' . ($isToday ? ' class="' . $this->classes['today'] . '"' : '') . '>';
+			if($isToday){
+				$out .= '<td class="' . $this->classes['today'] . '">';
+			} elseif( // check for days from the past
+				$date->format('Y') < $today['year']
+				|| $date->format('Y') == $today['year'] && $date->format('n') < $today['mon']
+				|| $date->format('Y') == $today['year'] && $date->format('n') == $today['mon'] && $i < $today['mday'] 
+				
+			){
+				$out .= '<td class="' . $this->classes['disable'] . '">';
+			} else {
+				$out .= '<td>';
+			}
 
 			$out .= sprintf('<time datetime="%s">%d</time>', $date->format('Y-m-d'), $i);
 

--- a/src/SimpleCalendar.php
+++ b/src/SimpleCalendar.php
@@ -241,10 +241,18 @@ class SimpleCalendar {
 			$next = date('M-Y', strtotime('+1 month', strtotime($now['year'].'-'.$now['mon'])));
 			$current = date('F Y', $this->now->getTimestamp());
 
+			$prevMonth = getdate(strtotime('-1 month', strtotime($now['year'].'-'.$now['mon'])));
+			
+			if($prevMonth['year'] < $today['year'] || $prevMonth['year'] == $today['year'] && $prevMonth['mon'] < $today['mon']) {
+				$linkToPast = ' '.$this->classes['disable'];
+			} else {
+				$linkToPast = '';
+			}
+
 			$topRow = <<<TAG
 <tr class="{$this->classes['top']}">
 	<th>
-		<a class="{$this->classes['previous']}" href="#" data-target-month="$prev">&lt;</a>
+		<a class="{$this->classes['previous']}$linkToPast" href="#" data-target-month="$prev">&lt;</a>
 	</th>
 	<th colspan="5">$current</th>
 	<th>

--- a/src/SimpleCalendar.php
+++ b/src/SimpleCalendar.php
@@ -16,29 +16,30 @@ class SimpleCalendar {
 	 *
 	 * @var string[]|null
 	 */
-	private $weekDayNames;
+	protected $weekDayNames;
 
 	/**
 	 * @var \DateTimeInterface
 	 */
-	private $now;
+	protected $now;
 
 	/**
 	 * @var \DateTimeInterface|null
 	 */
-	private $today;
+	protected $today;
 
-	private $classes = [
+	protected $classes = [
 		'calendar'     => 'SimpleCalendar',
 		'leading_day'  => 'SCprefix',
 		'trailing_day' => 'SCsuffix',
 		'today'        => 'today',
 		'event'        => 'event',
 		'events'       => 'events',
+		'disable'      => 'disable',
 	];
 
-	private $dailyHtml = [];
-	private $offset = 0;
+	protected $dailyHtml = [];
+	protected $offset = 0;
 
 	/**
 	 * @param \DateTimeInterface|int|string|null       $calendarDate
@@ -67,7 +68,7 @@ class SimpleCalendar {
 	 * @param \DateTimeInterface|int|string|null $date
 	 * @return \DateTimeInterface|null
 	 */
-	private function parseDate( $date = null ) {
+	protected function parseDate( $date = null ) {
 		if( $date instanceof \DateTimeInterface ) {
 			return $date;
 		}
@@ -306,7 +307,7 @@ TAG
 	/**
 	 * @param int $steps
 	 */
-	private function rotate( array &$data, $steps ) {
+	protected function rotate( array &$data, $steps ) {
 		$count = count($data);
 		if( $steps < 0 ) {
 			$steps = $count + $steps;
@@ -320,7 +321,7 @@ TAG
 	/**
 	 * @return string[]
 	 */
-	private function weekdays() {
+	protected function weekdays() {
 		if( $this->weekDayNames !== null ) {
 			$wDays = $this->weekDayNames;
 		} else {

--- a/src/SimpleCalendar.php
+++ b/src/SimpleCalendar.php
@@ -223,7 +223,7 @@ class SimpleCalendar {
 	 *
 	 * @return string
 	 */
-	public function render( $top = false) {
+	public function render( bool $top = false) {
 		$now   = getdate($this->now->getTimestamp());
 		$today = [ 'mday' => -1, 'mon' => -1, 'year' => -1 ];
 		if( $this->today !== null ) {
@@ -256,7 +256,7 @@ class SimpleCalendar {
 	</th>
 	<th colspan="5">$current</th>
 	<th>
-		<a class="{$this->classes['next']}" href="#" date-target-month="$next">&gt;</a>
+		<a class="{$this->classes['next']}" href="#" data-target-month="$next">&gt;</a>
 	</th>
 </tr>
 TAG;

--- a/src/SimpleCalendar.php
+++ b/src/SimpleCalendar.php
@@ -36,6 +36,9 @@ class SimpleCalendar {
 		'event'        => 'event',
 		'events'       => 'events',
 		'disable'      => 'disable',
+		'top'          => 'top',
+		'previous'     => 'previous',
+		'next'         => 'next',
 	];
 
 	protected $dailyHtml = [];
@@ -220,7 +223,7 @@ class SimpleCalendar {
 	 *
 	 * @return string
 	 */
-	public function render() {
+	public function render( $top = false) {
 		$now   = getdate($this->now->getTimestamp());
 		$today = [ 'mday' => -1, 'mon' => -1, 'year' => -1 ];
 		if( $this->today !== null ) {
@@ -233,8 +236,28 @@ class SimpleCalendar {
 		$weekDayIndex = date('N', mktime(0, 0, 1, $now['mon'], 1, $now['year'])) - $this->offset;
 		$daysInMonth  = cal_days_in_month(CAL_GREGORIAN, $now['mon'], $now['year']);
 
+		if($top){
+			$prev = date('M-Y', strtotime('-1 month', strtotime($now['year'].'-'.$now['mon'])));
+			$next = date('M-Y', strtotime('+1 month', strtotime($now['year'].'-'.$now['mon'])));
+			$current = date('F Y', $this->now->getTimestamp());
+
+			$topRow = <<<TAG
+<tr class="{$this->classes['top']}">
+	<th>
+		<a class="{$this->classes['previous']}" href="#" data-target-month="$prev">&lt;</a>
+	</th>
+	<th colspan="5">$current</th>
+	<th>
+		<a class="{$this->classes['next']}" href="#" date-target-month="$next">&gt;</a>
+	</th>
+</tr>
+TAG;
+		} else {
+			$topRow = '';
+		}
+
 		$out = <<<TAG
-<table cellpadding="0" cellspacing="0" class="{$this->classes['calendar']}"><thead><tr>
+<table cellpadding="0" cellspacing="0" class="{$this->classes['calendar']}"><thead>{$topRow}<tr>
 TAG;
 
 		foreach( $daysOfWeek as $dayName ) {

--- a/test/SimpleCalendarTest.php
+++ b/test/SimpleCalendarTest.php
@@ -2,17 +2,16 @@
 
 use donatj\SimpleCalendar;
 
-class SimpleCalendarTest extends PHPUnit_Framework_TestCase {
+class SimpleCalendarTest extends \PHPUnit\Framework\TestCase {
 
 	public function testCurrentMonth() {
 		$cal = new SimpleCalendar();
-		$this->assertContains('class="today"', $cal->show(false));
+		$this->assertStringContainsString('class="today"', $cal->show(false));
 	}
 
-	/**
-	 * @expectedException \InvalidArgumentException
-	 */
+
 	public function testBadDailyHtmlDates(){
+		$this->expectException(InvalidArgumentException::class);
 		$cal = new SimpleCalendar('June 2010', 'June 5 2010');
 		$cal->addDailyHtml('foo', 'tomorrow', 'yesterday');
 	}
@@ -31,7 +30,7 @@ class SimpleCalendarTest extends PHPUnit_Framework_TestCase {
 		$cal->addDailyHtml( 'Sample Event', 'June 15 2010' );
 		$cal_html = $cal->render();
 		foreach( $defaults as $class ) {
-			$this->assertContains('class="' . $class . '"', $cal_html);
+			$this->assertStringContainsString('class="' . $class . '"', $cal_html);
 		}
 	}
 
@@ -51,13 +50,13 @@ class SimpleCalendarTest extends PHPUnit_Framework_TestCase {
 		$cal_html = $cal->render();
 
 		foreach( $classes as $class ) {
-			$this->assertContains('class="' . $class . '"', $cal_html);
+			$this->assertStringContainsString('class="' . $class . '"', $cal_html);
 		}
 	}
 
 	public function testCurrentMonth_yearRegression() {
 		$cal = new SimpleCalendar(sprintf('%d-%d-%d', (date('Y') - 1), date('n'), date('d')));
-		$this->assertNotContains('class="today"', $cal->show(false));
+		$this->assertStringNotContainsString('class="today"', $cal->show(false));
 	}
 
 	public function testTagOpenCloseMismatch_regression() {
@@ -99,48 +98,48 @@ class SimpleCalendarTest extends PHPUnit_Framework_TestCase {
 				[ 'class' => 'SCprefix', 'text' => ' ', ],
 				[ 'class' => 'SCprefix', 'text' => ' ', ],
 				[ 'class' => 'SCprefix', 'text' => ' ', ],
-				[ 'class' => '', 'text' => '1', 'date' => '2016-06-01', ],
-				[ 'class' => '', 'text' => '2', 'date' => '2016-06-02', ],
-				[ 'class' => '', 'text' => '3', 'date' => '2016-06-03', ],
-				[ 'class' => '', 'text' => '4', 'date' => '2016-06-04', ],
+				[ 'class' => 'disable', 'text' => '1', 'date' => '2016-06-01', ],
+				[ 'class' => 'disable', 'text' => '2', 'date' => '2016-06-02', ],
+				[ 'class' => 'disable', 'text' => '3', 'date' => '2016-06-03', ],
+				[ 'class' => 'disable', 'text' => '4', 'date' => '2016-06-04', ],
 			],
 
 			[
-				[ 'class' => '', 'text' => '5', 'date' => '2016-06-05', ],
-				[ 'class' => '', 'text' => '6', 'date' => '2016-06-06', ],
-				[ 'class' => '', 'text' => '7', 'date' => '2016-06-07', ],
-				[ 'class' => '', 'text' => '8', 'date' => '2016-06-08', ],
-				[ 'class' => '', 'text' => '9', 'date' => '2016-06-09', ],
-				[ 'class' => '', 'text' => '10', 'date' => '2016-06-10', ],
-				[ 'class' => '', 'text' => '11', 'date' => '2016-06-11', ],
+				[ 'class' => 'disable', 'text' => '5', 'date' => '2016-06-05', ],
+				[ 'class' => 'disable', 'text' => '6', 'date' => '2016-06-06', ],
+				[ 'class' => 'disable', 'text' => '7', 'date' => '2016-06-07', ],
+				[ 'class' => 'disable', 'text' => '8', 'date' => '2016-06-08', ],
+				[ 'class' => 'disable', 'text' => '9', 'date' => '2016-06-09', ],
+				[ 'class' => 'disable', 'text' => '10', 'date' => '2016-06-10', ],
+				[ 'class' => 'disable', 'text' => '11', 'date' => '2016-06-11', ],
 			],
 
 			[
-				[ 'class' => '', 'text' => '12', 'date' => '2016-06-12', ],
-				[ 'class' => '', 'text' => '13', 'date' => '2016-06-13', ],
-				[ 'class' => '', 'text' => '14', 'date' => '2016-06-14', ],
-				[ 'class' => '', 'text' => '15', 'date' => '2016-06-15', ],
-				[ 'class' => '', 'text' => '16', 'date' => '2016-06-16', ],
-				[ 'class' => '', 'text' => '17', 'date' => '2016-06-17', ],
-				[ 'class' => '', 'text' => '18', 'date' => '2016-06-18', ],
+				[ 'class' => 'disable', 'text' => '12', 'date' => '2016-06-12', ],
+				[ 'class' => 'disable', 'text' => '13', 'date' => '2016-06-13', ],
+				[ 'class' => 'disable', 'text' => '14', 'date' => '2016-06-14', ],
+				[ 'class' => 'disable', 'text' => '15', 'date' => '2016-06-15', ],
+				[ 'class' => 'disable', 'text' => '16', 'date' => '2016-06-16', ],
+				[ 'class' => 'disable', 'text' => '17', 'date' => '2016-06-17', ],
+				[ 'class' => 'disable', 'text' => '18', 'date' => '2016-06-18', ],
 			],
 
 			[
-				[ 'class' => '', 'text' => '19', 'date' => '2016-06-19', ],
-				[ 'class' => '', 'text' => '20', 'date' => '2016-06-20', ],
-				[ 'class' => '', 'text' => '21', 'date' => '2016-06-21', ],
-				[ 'class' => '', 'text' => '22', 'date' => '2016-06-22', ],
-				[ 'class' => '', 'text' => '23', 'date' => '2016-06-23', ],
-				[ 'class' => '', 'text' => '24', 'date' => '2016-06-24', ],
-				[ 'class' => '', 'text' => '25', 'date' => '2016-06-25', ],
+				[ 'class' => 'disable', 'text' => '19', 'date' => '2016-06-19', ],
+				[ 'class' => 'disable', 'text' => '20', 'date' => '2016-06-20', ],
+				[ 'class' => 'disable', 'text' => '21', 'date' => '2016-06-21', ],
+				[ 'class' => 'disable', 'text' => '22', 'date' => '2016-06-22', ],
+				[ 'class' => 'disable', 'text' => '23', 'date' => '2016-06-23', ],
+				[ 'class' => 'disable', 'text' => '24', 'date' => '2016-06-24', ],
+				[ 'class' => 'disable', 'text' => '25', 'date' => '2016-06-25', ],
 			],
 
 			[
-				[ 'class' => '', 'text' => '26', 'date' => '2016-06-26', ],
-				[ 'class' => '', 'text' => '27', 'date' => '2016-06-27', ],
-				[ 'class' => '', 'text' => '28', 'date' => '2016-06-28', ],
-				[ 'class' => '', 'text' => '29', 'date' => '2016-06-29', ],
-				[ 'class' => '', 'text' => '30', 'date' => '2016-06-30', ],
+				[ 'class' => 'disable', 'text' => '26', 'date' => '2016-06-26', ],
+				[ 'class' => 'disable', 'text' => '27', 'date' => '2016-06-27', ],
+				[ 'class' => 'disable', 'text' => '28', 'date' => '2016-06-28', ],
+				[ 'class' => 'disable', 'text' => '29', 'date' => '2016-06-29', ],
+				[ 'class' => 'disable', 'text' => '30', 'date' => '2016-06-30', ],
 				[ 'class' => 'SCsuffix', 'text' => ' ', ],
 				[ 'class' => 'SCsuffix', 'text' => ' ', ],
 			],
@@ -171,44 +170,44 @@ class SimpleCalendarTest extends PHPUnit_Framework_TestCase {
 				[ 'class' => 'SCprefix', 'text' => ' ', ],
 				[ 'class' => 'SCprefix', 'text' => ' ', ],
 				[ 'class' => 'SCprefix', 'text' => ' ', ],
-				[ 'class' => '', 'text' => '1', 'date' => '2016-06-01', ],
-				[ 'class' => '', 'text' => '2', 'date' => '2016-06-02', ],
+				[ 'class' => 'disable', 'text' => '1', 'date' => '2016-06-01', ],
+				[ 'class' => 'disable', 'text' => '2', 'date' => '2016-06-02', ],
 			],
 			[
-				[ 'class' => '', 'text' => '3', 'date' => '2016-06-03', ],
-				[ 'class' => '', 'text' => '4', 'date' => '2016-06-04', ],
-				[ 'class' => '', 'text' => '5', 'date' => '2016-06-05', ],
-				[ 'class' => '', 'text' => '6', 'date' => '2016-06-06', ],
-				[ 'class' => '', 'text' => '7', 'date' => '2016-06-07', ],
-				[ 'class' => '', 'text' => '8', 'date' => '2016-06-08', ],
-				[ 'class' => '', 'text' => '9', 'date' => '2016-06-09', ],
+				[ 'class' => 'disable', 'text' => '3', 'date' => '2016-06-03', ],
+				[ 'class' => 'disable', 'text' => '4', 'date' => '2016-06-04', ],
+				[ 'class' => 'disable', 'text' => '5', 'date' => '2016-06-05', ],
+				[ 'class' => 'disable', 'text' => '6', 'date' => '2016-06-06', ],
+				[ 'class' => 'disable', 'text' => '7', 'date' => '2016-06-07', ],
+				[ 'class' => 'disable', 'text' => '8', 'date' => '2016-06-08', ],
+				[ 'class' => 'disable', 'text' => '9', 'date' => '2016-06-09', ],
 			],
 			[
-				[ 'class' => '', 'text' => '10', 'date' => '2016-06-10', ],
-				[ 'class' => '', 'text' => '11', 'date' => '2016-06-11', ],
-				[ 'class' => '', 'text' => '12', 'date' => '2016-06-12', ],
-				[ 'class' => '', 'text' => '13', 'date' => '2016-06-13', ],
-				[ 'class' => '', 'text' => '14', 'date' => '2016-06-14', ],
-				[ 'class' => '', 'text' => '15', 'date' => '2016-06-15', ],
-				[ 'class' => '', 'text' => '16', 'date' => '2016-06-16', ],
+				[ 'class' => 'disable', 'text' => '10', 'date' => '2016-06-10', ],
+				[ 'class' => 'disable', 'text' => '11', 'date' => '2016-06-11', ],
+				[ 'class' => 'disable', 'text' => '12', 'date' => '2016-06-12', ],
+				[ 'class' => 'disable', 'text' => '13', 'date' => '2016-06-13', ],
+				[ 'class' => 'disable', 'text' => '14', 'date' => '2016-06-14', ],
+				[ 'class' => 'disable', 'text' => '15', 'date' => '2016-06-15', ],
+				[ 'class' => 'disable', 'text' => '16', 'date' => '2016-06-16', ],
 			],
 			[
-				[ 'class' => '', 'text' => '17', 'date' => '2016-06-17', ],
-				[ 'class' => '', 'text' => '18', 'date' => '2016-06-18', ],
-				[ 'class' => '', 'text' => '19', 'date' => '2016-06-19', ],
-				[ 'class' => '', 'text' => '20', 'date' => '2016-06-20', ],
-				[ 'class' => '', 'text' => '21', 'date' => '2016-06-21', ],
-				[ 'class' => '', 'text' => '22', 'date' => '2016-06-22', ],
-				[ 'class' => '', 'text' => '23', 'date' => '2016-06-23', ],
+				[ 'class' => 'disable', 'text' => '17', 'date' => '2016-06-17', ],
+				[ 'class' => 'disable', 'text' => '18', 'date' => '2016-06-18', ],
+				[ 'class' => 'disable', 'text' => '19', 'date' => '2016-06-19', ],
+				[ 'class' => 'disable', 'text' => '20', 'date' => '2016-06-20', ],
+				[ 'class' => 'disable', 'text' => '21', 'date' => '2016-06-21', ],
+				[ 'class' => 'disable', 'text' => '22', 'date' => '2016-06-22', ],
+				[ 'class' => 'disable', 'text' => '23', 'date' => '2016-06-23', ],
 			],
 			[
-				[ 'class' => '', 'text' => '24', 'date' => '2016-06-24', ],
-				[ 'class' => '', 'text' => '25', 'date' => '2016-06-25', ],
-				[ 'class' => '', 'text' => '26', 'date' => '2016-06-26', ],
-				[ 'class' => '', 'text' => '27', 'date' => '2016-06-27', ],
-				[ 'class' => '', 'text' => '28', 'date' => '2016-06-28', ],
-				[ 'class' => '', 'text' => '29', 'date' => '2016-06-29', ],
-				[ 'class' => '', 'text' => '30', 'date' => '2016-06-30', ],
+				[ 'class' => 'disable', 'text' => '24', 'date' => '2016-06-24', ],
+				[ 'class' => 'disable', 'text' => '25', 'date' => '2016-06-25', ],
+				[ 'class' => 'disable', 'text' => '26', 'date' => '2016-06-26', ],
+				[ 'class' => 'disable', 'text' => '27', 'date' => '2016-06-27', ],
+				[ 'class' => 'disable', 'text' => '28', 'date' => '2016-06-28', ],
+				[ 'class' => 'disable', 'text' => '29', 'date' => '2016-06-29', ],
+				[ 'class' => 'disable', 'text' => '30', 'date' => '2016-06-30', ],
 			],
 		];
 


### PR DESCRIPTION
Hi 

I was trying to extend your class originally. Still, all those references to private properties like $this->now made it impossible so here I propose to make them all protected instead.

My main extension was to make all the date from the past to be styled differently and to exclude them from JS selection when picking up the date - so I've added a few lines in render method and also an additional class called "disable".